### PR TITLE
Implement HasAllFlags and fix a couple bugs

### DIFF
--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -855,7 +855,7 @@ bool BasicBlock::CloneBlockState(
     Compiler* compiler, BasicBlock* to, const BasicBlock* from, unsigned varNum, int varVal)
 {
     assert(to->bbStmtList == nullptr);
-    to->SetFlagsRaw(from->GetFlagsRaw());
+    to->CopyFlags(from);
     to->bbWeight = from->bbWeight;
     BlockSetOps::AssignAllowUninitRhs(compiler, to->bbReach, from->bbReach);
     to->copyEHRegion(from);

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -469,27 +469,32 @@ enum BasicBlockFlags : unsigned __int64
     BBF_COPY_PROPAGATE = BBF_HAS_NEWOBJ | BBF_HAS_NULLCHECK | BBF_HAS_IDX_LEN | BBF_HAS_MD_IDX_LEN | BBF_HAS_MDARRAYREF,
 };
 
-inline constexpr BasicBlockFlags operator ~(BasicBlockFlags a)
+FORCEINLINE
+constexpr BasicBlockFlags operator ~(BasicBlockFlags a)
 {
     return (BasicBlockFlags)(~(unsigned __int64)a);
 }
 
-inline constexpr BasicBlockFlags operator |(BasicBlockFlags a, BasicBlockFlags b)
+FORCEINLINE
+constexpr BasicBlockFlags operator |(BasicBlockFlags a, BasicBlockFlags b)
 {
     return (BasicBlockFlags)((unsigned __int64)a | (unsigned __int64)b);
 }
 
-inline constexpr BasicBlockFlags operator &(BasicBlockFlags a, BasicBlockFlags b)
+FORCEINLINE
+constexpr BasicBlockFlags operator &(BasicBlockFlags a, BasicBlockFlags b)
 {
     return (BasicBlockFlags)((unsigned __int64)a & (unsigned __int64)b);
 }
 
-inline BasicBlockFlags& operator |=(BasicBlockFlags& a, BasicBlockFlags b)
+FORCEINLINE 
+BasicBlockFlags& operator |=(BasicBlockFlags& a, BasicBlockFlags b)
 {
     return a = (BasicBlockFlags)((unsigned __int64)a | (unsigned __int64)b);
 }
 
-inline BasicBlockFlags& operator &=(BasicBlockFlags& a, BasicBlockFlags b)
+FORCEINLINE 
+BasicBlockFlags& operator &=(BasicBlockFlags& a, BasicBlockFlags b)
 {
     return a = (BasicBlockFlags)((unsigned __int64)a & (unsigned __int64)b);
 }
@@ -709,15 +714,38 @@ public:
         return (bbFlags & flag);
     }
 
+    // HasAnyFlag takes a set of flags OR'd together. It requires at least
+    // two flags to be set (or else you should use `HasFlag`).
+    // It is true if *any* of those flags are set on the block.
     BasicBlockFlags HasAnyFlag(const BasicBlockFlags flags) const
     {
-        // Assert flag is multiple BasicBlockFlags OR'd together
-        // by checking if it is not a power of 2
-        // (HasAnyFlag expects to check only one flag at a time)
-        assert(!isPow2(flags));
+        assert((flags != BBF_EMPTY) && !isPow2(flags));
         return (bbFlags & flags);
     }
 
+    // HasAllFlags takes a set of flags OR'd together. It requires at least
+    // two flags to be set (or else you should use `HasFlag`).
+    // It is true if *all* of those flags are set on the block.
+    bool HasAllFlags(const BasicBlockFlags flags) const
+    {
+        assert((flags != BBF_EMPTY) && !isPow2(flags));
+        return (bbFlags & flags) == flags;
+    }
+
+    // Copy all the flags from another block. This is a complete copy; any flags
+    // that were previously set on this block are overwritten.
+    void CopyFlags(const BasicBlock* block)
+    {
+        bbFlags = block->bbFlags;
+    }
+
+    // Copy the values of a specific set of flags from another block. All flags
+    // not in the mask are preserved. Note however, that only set flags are copied;
+    // if a flag in the mask is already set in this block, it will not be reset!
+    // (Perhaps we should have a `ReplaceFlags` function that first clears the
+    // bits in `mask` before doing the copy. Possibly we should assert that
+    // `(bbFlags & mask) == 0` under the assumption that we copy flags when
+    // creating a new block from scratch.)
     void CopyFlags(const BasicBlock* block, const BasicBlockFlags mask)
     {
         bbFlags |= (block->bbFlags & mask);

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -4760,7 +4760,7 @@ BasicBlock* Compiler::fgSplitBlockAtEnd(BasicBlock* curr)
     newBlock->inheritWeight(curr);
 
     // Set the new block's flags. Note that the new block isn't BBF_INTERNAL unless the old block is.
-    newBlock->SetFlagsRaw(curr->GetFlagsRaw());
+    newBlock->CopyFlags(curr);
 
     // Remove flags that the new block can't have.
     newBlock->RemoveFlags(BBF_LOOP_HEAD | BBF_FUNCLET_BEG | BBF_LOOP_PREHEADER | BBF_KEEP_BBJ_ALWAYS | BBF_PATCHPOINT |

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -1976,7 +1976,7 @@ BasicBlock* Compiler::impPushCatchArgOnStack(BasicBlock* hndBlk, CORINFO_CLASS_H
     // hit only under JIT stress. See if the block is the one we injected.
     // Note that EH canonicalization can inject internal blocks here. We might
     // be able to re-use such a block (but we don't, right now).
-    if (hndBlk->HasAnyFlag(BBF_IMPORTED | BBF_INTERNAL | BBF_DONT_REMOVE))
+    if (hndBlk->HasAllFlags(BBF_IMPORTED | BBF_INTERNAL | BBF_DONT_REMOVE))
     {
         Statement* stmt = hndBlk->firstStmt();
 
@@ -5015,7 +5015,7 @@ void Compiler::impResetLeaveBlock(BasicBlock* block, unsigned jmpAddr)
     if (block->KindIs(BBJ_CALLFINALLY))
     {
         BasicBlock* dupBlock = BasicBlock::New(this, BBJ_CALLFINALLY, block->GetJumpDest());
-        dupBlock->SetFlagsRaw(block->GetFlagsRaw());
+        dupBlock->CopyFlags(block);
         fgAddRefPred(dupBlock->GetJumpDest(), dupBlock);
         dupBlock->copyEHRegion(block);
         dupBlock->bbCatchTyp = block->bbCatchTyp;
@@ -11801,7 +11801,7 @@ void Compiler::ReimportSpillClique::Visit(SpillCliqueDir predOrSucc, BasicBlock*
 
         // This block has either never been imported (EntryState == NULL) or it failed
         // verification. Neither state requires us to force it to be imported now.
-        assert((blk->bbEntryState == nullptr) || !blk->HasFlag(BBF_FAILED_VERIFICATION));
+        assert((blk->bbEntryState == nullptr) || blk->HasFlag(BBF_FAILED_VERIFICATION));
         return;
     }
 


### PR DESCRIPTION
Fix 2 bugs in importer with flags conversion to functions.

Implement full `CopyFlags` to eliminate some GetFlagsRaw cases.

For BasicBlockFlags operators, mark them as FORCEINLINE. They have always been expected to be fully inlined, but I found some cases in Release builds where they were not.